### PR TITLE
Resolve rejections to lacina promises

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [org.clojure/tools.logging "0.6.0"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]
                                        [org.clojure/clojurescript "1.10.597"]]}
-             :lacinia  {:dependencies [[com.walmartlabs/lacinia-pedestal "0.14.0-alpha-2"]]}
+             :test     {:dependencies [[com.walmartlabs/lacinia-pedestal "0.14.0-alpha-2"]]}
              :dev      {:dependencies [[binaryage/devtools "1.0.0"]
                                        [com.bhauman/figwheel-main "0.2.1"]
                                        [org.clojure/tools.reader "1.2.2"]

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [org.clojure/tools.logging "0.6.0"]]
   :profiles {:provided {:dependencies [[org.clojure/clojure "1.10.1"]
                                        [org.clojure/clojurescript "1.10.597"]]}
+             :lacinia  {:dependencies [[com.walmartlabs/lacinia-pedestal "0.14.0-alpha-2"]]}
              :dev      {:dependencies [[binaryage/devtools "1.0.0"]
                                        [com.bhauman/figwheel-main "0.2.1"]
                                        [org.clojure/tools.reader "1.2.2"]

--- a/src/superlifter/lacinia.clj
+++ b/src/superlifter/lacinia.clj
@@ -2,7 +2,8 @@
   (:require [superlifter.core :as s]
             [superlifter.api :as api]
             [io.pedestal.interceptor :refer [interceptor]]
-            [com.walmartlabs.lacinia.resolve :as resolve]))
+            [com.walmartlabs.lacinia.resolve :as resolve]
+            [promesa.core :as prom]))
 
 (defn inject-superlifter [superlifter-args]
   (interceptor
@@ -14,7 +15,7 @@
 
 (defn ->lacinia-promise [sl-result]
   (let [l-prom (resolve/resolve-promise)]
-    (api/unwrap #(resolve/deliver! l-prom %) sl-result)
+    (api/unwrap #(resolve/deliver! l-prom %) (prom/catch sl-result prom/resolved))
     l-prom))
 
 (defmacro with-superlifter [ctx body]

--- a/test/superlifter/lacinia_test.clj
+++ b/test/superlifter/lacinia_test.clj
@@ -1,0 +1,17 @@
+(ns superlifter.lacinia-test
+  (:require
+   [clojure.test :refer :all]
+   [com.walmartlabs.lacinia.resolve :refer [on-deliver!]]
+   [promesa.core :as prom]
+   [superlifter.lacinia :as sl]))
+
+(deftest ->lacinia-promise
+  (let [ex (ex-info "Expected" {})]
+    (are [input expected] (= expected
+                             (let [v (promise)]
+                               (on-deliver! (sl/->lacinia-promise input) #(deliver v %))
+                               (deref v 5 ::timeout)))
+      ::value                                           ::value
+      (prom/promise ::value)                            ::value
+      (doto (prom/deferred) (prom/resolve! ::value))    ::value
+      (doto (prom/deferred) (prom/reject! ex))          ex)))


### PR DESCRIPTION
previously only successful promises were resolved, resulting in an infinite block in lacinia. Exceptions are now passed through the promesa promise into the lacinia promise, which is supported by lacinia.


This caused an issue in our setup where exceptions were lost, and workers were blocking on rejected promesa promises.