### PR TITLE
Avoid reflection overhead in Thread.sleep

### DIFF
--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -89,8 +89,8 @@
 
 (defn- fetch-all-handling-errors! [context bucket-id]
   (try (prom/catch (fetch-bucket! context bucket-id)
-                   (fn [error]
-                     (log :warn "Fetch failed" error)))
+           (fn [error]
+              (log :warn "Fetch failed" error)))
        (catch Throwable t
          (log :warn "Fetch failed" t))))
 

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -89,7 +89,7 @@
 
 (defn- fetch-all-handling-errors! [context bucket-id]
   (try (prom/catch (fetch-bucket! context bucket-id)
-           (fn [error] 
+           (fn [error]
              (log :warn "Fetch failed" error)))
        (catch Throwable t
          (log :warn "Fetch failed" t))))

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -89,8 +89,8 @@
 
 (defn- fetch-all-handling-errors! [context bucket-id]
   (try (prom/catch (fetch-bucket! context bucket-id)
-           (fn [error]
-              (log :warn "Fetch failed" error)))
+           (fn [error] 
+             (log :warn "Fetch failed" error)))
        (catch Throwable t
          (log :warn "Fetch failed" t))))
 

--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -89,8 +89,8 @@
 
 (defn- fetch-all-handling-errors! [context bucket-id]
   (try (prom/catch (fetch-bucket! context bucket-id)
-           (fn [error]
-             (log :warn "Fetch failed" error)))
+                   (fn [error]
+                     (log :warn "Fetch failed" error)))
        (catch Throwable t
          (log :warn "Fetch failed" t))))
 
@@ -121,7 +121,7 @@
 
 (defmethod start-trigger! :interval [_ context bucket-id opts]
   (let [watcher #?(:clj (future (loop []
-                                  (Thread/sleep (:interval opts))
+                                  (Thread/sleep ^long (:interval opts))
                                   (fetch-all-handling-errors! context bucket-id)
                                   (recur)))
                    :cljs (js/setInterval #(fetch-all-handling-errors! context bucket-id)
@@ -151,7 +151,7 @@
         watcher #?(:clj (future (loop []
                                   (let [lu @last-updated]
                                     (cond
-                                      (nil? lu) (do (Thread/sleep interval)
+                                      (nil? lu) (do (Thread/sleep ^long interval)
                                                     (recur))
 
                                       (= :exit lu) nil
@@ -162,7 +162,7 @@
                                           (recur))
 
                                       :else
-                                      (do (Thread/sleep (- interval (- (System/currentTimeMillis) lu)))
+                                      (do (Thread/sleep ^long (- interval (- (System/currentTimeMillis) lu)))
                                           (recur))))))
                    :cljs (js/setTimeout check-debounced 0 context bucket-id interval last-updated))]
     (assoc opts


### PR DESCRIPTION
Starting from Java 19, an overloaded version of Thread.sleep that accepts a Duration parameter was introduced. This can cause runtime performance overhead due to reflection when using Java 19 or later.

To address this issue, explicit java.Long type hints are added to ensure that the correct Thread.sleep method is called directly, avoiding reflection and improving performance.

documentation: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#sleep(long)