### PR TITLE
Fix race condition in `:debounced` trigger that can silently kill the watcher

### DIFF
--- a/src/superlifter/core.cljc
+++ b/src/superlifter/core.cljc
@@ -129,40 +129,45 @@
     (assoc opts :stop-fn #?(:clj #(future-cancel watcher)
                             :cljs #(js/clearInterval watcher)))))
 
+(defn- debounce-active? [lu]
+  (and (some? lu) (not= :exit lu)))
+
 #?(:cljs
    (defn- check-debounced [context bucket-id interval last-updated]
-     (let [lu @last-updated]
+     (let [lu @last-updated
+           remaining (when (debounce-active? lu) (- interval (- (js/Date.) lu)))]
        (cond
          (nil? lu) (js/setTimeout check-debounced interval context bucket-id interval last-updated)
 
          (= :exit lu) nil
 
-         (<= interval (- (js/Date.) lu))
+         (<= remaining 0)
          (do (fetch-all-handling-errors! context bucket-id)
              (compare-and-set! last-updated lu nil)
              (js/setTimeout check-debounced 0 context bucket-id interval last-updated))
 
          :else
-         (js/setTimeout check-debounced (- interval (- (js/Date.) lu)) context bucket-id interval last-updated)))))
+         (js/setTimeout check-debounced remaining context bucket-id interval last-updated)))))
 
 (defmethod start-trigger! :debounced [_ context bucket-id opts]
   (let [interval (:interval opts)
         last-updated (atom nil)
         watcher #?(:clj (future (loop []
-                                  (let [lu @last-updated]
+                                  (let [lu @last-updated
+                                        remaining (when (debounce-active? lu) (- interval (- (System/currentTimeMillis) lu)))]
                                     (cond
                                       (nil? lu) (do (Thread/sleep ^long interval)
                                                     (recur))
 
                                       (= :exit lu) nil
 
-                                      (<= interval (- (System/currentTimeMillis) lu))
+                                      (<= remaining 0)
                                       (do (fetch-all-handling-errors! context bucket-id)
                                           (compare-and-set! last-updated lu nil)
                                           (recur))
 
                                       :else
-                                      (do (Thread/sleep ^long (- interval (- (System/currentTimeMillis) lu)))
+                                      (do (Thread/sleep ^long remaining)
                                           (recur))))))
                    :cljs (js/setTimeout check-debounced 0 context bucket-id interval last-updated))]
     (assoc opts


### PR DESCRIPTION
The `:debounced` trigger in `core.cljc` calls `(System/currentTimeMillis)` (JVM) / `(js/Date.)` (ClojureScript) twice in the same loop iteration: Once in the condition check, and once in the `Thread/sleep` / `setTimeout` calculation. If time advances between these two calls (e.g., due to GC pauses, CPU throttling, or OS scheduling), the sleep duration `(- interval (- (System/currentTimeMillis) lu))` can become negative.

On the JVM, this causes `Thread/sleep` to throw `IllegalArgumentException`, which kills the watcher future silently. Any pending promises will then hang indefinitely since nothing is left to trigger their resolution.

## How to reproduce

Most likely to occur under load with short debounce intervals, where `lu` is close to `now` and the time difference crosses the interval threshold between the two `System/currentTimeMillis` calls.

## How to fix

Compute `remaining` once per iteration and reuse it in both the condition check and the sleep/setTimeout call:

```clojure
;; Before
(let [lu @last-updated]
  (cond
    ...
    (<= interval (- (System/currentTimeMillis) lu)) ...
    :else
    (do (Thread/sleep ^long (- interval (- (System/currentTimeMillis) lu)))
        (recur))))

;; After
(let [lu @last-updated
      remaining (when (debounce-active? lu) (- interval (- (System/currentTimeMillis) lu)))]
  (cond
    ...
    (<= remaining 0) ...
    :else
    (do (Thread/sleep ^long remaining)
        (recur))))
```

Where `debounce-active?` is a small predicate that checks `lu` is a timestamp (not `nil` or `:exit`):

```clojure
(defn- debounce-active? [lu]
  (and (some? lu) (not= :exit lu)))
```

The same fix applies to the ClojureScript `check-debounced` function with `(js/Date.)`.